### PR TITLE
update from upstream

### DIFF
--- a/.github/workflows/build-rust.yml
+++ b/.github/workflows/build-rust.yml
@@ -357,8 +357,8 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - cargo-build
-      - cargo-fmt
       - cargo-clippy-and-report
+      - cargo-fmt
       - cargo-test-and-report
     if: |
       always()

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Rust toolchain setup
-FROM --platform=${BUILDPLATFORM} rust:1.87.0@sha256:251cec8da4689d180f124ef00024c2f83f79d9bf984e43c180a598119e326b84 AS rust-base
+FROM --platform=${BUILDPLATFORM} rust:1.88.0@sha256:1928f85f204effc91fddc53875afd042b651552fde6ee11acaafde641942dd70 AS rust-base
 
 ARG APPLICATION_NAME
 
@@ -25,10 +25,11 @@ ARG TARGET=aarch64-unknown-linux-musl
 
 FROM rust-${TARGETPLATFORM//\//-} AS rust-cargo-build
 
-COPY ./build-scripts/setup-env.sh .
+COPY ./build-scripts /build-scripts
+
 RUN --mount=type=cache,id=apt-cache,from=rust-base,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,id=apt-lib,from=rust-base,target=/var/lib/apt,sharing=locked \
-    ./setup-env.sh
+    /build-scripts/setup-env.sh
 
 RUN rustup target add ${TARGET}
 
@@ -37,39 +38,32 @@ RUN rustup target add ${TARGET}
 # This allows us to copy in the source in a different layer which in turn allows us to leverage Docker's layer caching
 # That means that if our dependencies don't change rebuilding is much faster
 WORKDIR /build
-RUN cargo new ${APPLICATION_NAME}
 
-WORKDIR /build/${APPLICATION_NAME}
+RUN cargo init --name ${APPLICATION_NAME}
 
-COPY ./build-scripts/build.sh .
+COPY ./.cargo ./Cargo.toml ./Cargo.lock ./
 
-COPY .cargo ./.cargo
-COPY Cargo.toml Cargo.lock ./
-
-# because have our source in a subfolder, we need to ensure that the path in the [[bin]] section exists
-RUN mkdir -p back-end/src && mv src/main.rs back-end/src/main.rs
-
-RUN --mount=type=cache,target=/build/${APPLICATION_NAME}/target \
-    --mount=type=cache,id=cargo-git,target=/usr/local/cargo/git/db,sharing=locked \
-    --mount=type=cache,id=cargo-registery,target=/usr/local/cargo/registry/,sharing=locked \
-    ./build.sh build --release --target ${TARGET}
+RUN --mount=type=cache,target=/build/target,sharing=locked \
+    --mount=type=cache,id=cargo-git,target=/usr/local/cargo/git/db \
+    --mount=type=cache,id=cargo-registry,target=/usr/local/cargo/registry \
+    /build-scripts/build.sh build --release --target ${TARGET}
 
 # Rust full build
 FROM rust-cargo-build AS rust-build
 
-WORKDIR /build/${APPLICATION_NAME}
+WORKDIR /build
 
 # now we copy in the source which is more prone to changes and build it
-COPY back-end ./back-end
+COPY ./back-end ./back-end
 
 # ensure cargo picks up on the change
 RUN touch ./back-end/src/main.rs
 
 # --release not needed, it is implied with install
-RUN --mount=type=cache,target=/build/${APPLICATION_NAME}/target \
-    --mount=type=cache,id=cargo-git,target=/usr/local/cargo/git/db,sharing=locked \
-    --mount=type=cache,id=cargo-registery,target=/usr/local/cargo/registry/,sharing=locked \
-    ./build.sh install --path . --locked --target ${TARGET} --root /output
+RUN --mount=type=cache,target=/build/target,sharing=locked \
+    --mount=type=cache,id=cargo-git,target=/usr/local/cargo/git/db \
+    --mount=type=cache,id=cargo-registry,target=/usr/local/cargo/registry \
+    /build-scripts/build.sh install --path . --locked --target ${TARGET} --root /output
 
 # Front-end (NPM) build
 FROM --platform=${BUILDPLATFORM} node:22.17.0-alpine@sha256:5340cbfc2df14331ab021555fdd9f83f072ce811488e705b0e736b11adeec4bb AS typescript-build
@@ -109,13 +103,13 @@ ARG APPLICATION_NAME
 COPY --from=passwd-build /tmp/group_appuser /etc/group
 COPY --from=passwd-build /tmp/passwd_appuser /etc/passwd
 
-USER appuser
-
-WORKDIR /app
-
 COPY --from=rust-build /output/bin/${APPLICATION_NAME} /app/entrypoint
 COPY --from=typescript-build /build/dist /app/dist
 
+USER appuser
+
 ENV RUST_BACKTRACE=full
+
+WORKDIR /app
 
 ENTRYPOINT ["/app/entrypoint"]


### PR DESCRIPTION
- **chore(deps): update node.js to v22.17.0**
- **chore(deps): update returntocorp/semgrep docker tag to v1.127.0**
- **chore(deps): update dependency prettier to v3.6.1**
- **chore: cleanup**
- **chore: don't push image cargo build/test/... failed**
- **chore: fix dockerfile instruction order**
- **chore(deps): update returntocorp/semgrep docker tag to v1.127.1**
- **chore(deps): update prettier-plugin-sh (npm) to v0.18.0**
- **chore(deps): update rust docker tag to v1.88.0**
- **chore(deps): update rust to v1.88.0**
