### PR TITLE
update from upstream

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Rust toolchain setup
-FROM --platform=${BUILDPLATFORM} rust:1.89.0-trixie@sha256:57407b378b2b6e07b48a6135a20c87cc22ea6e249c0acf6cb1833ead3cf116e9 AS rust-base
+FROM --platform=${BUILDPLATFORM} rust:1.90.0-trixie@sha256:eabb786e74b520e7ea45baca03ea20c3e8c6dc037c392d457badf05d8e5818b5 AS rust-base
 
 ARG APPLICATION_NAME
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
- **chore(deps): update rust to v1.90.0**
- **fix: clippy 1.90 fixes**
- **fix: macro to await linux-only signals**
- **chore(deps): update rust to v1.90.0**
- **fix: image as well because renovate is slow**
- **chore(deps): update rust docker tag to v1.90.0**
- **chore(deps): update rust to v1.90.0**
